### PR TITLE
Update subject line to have 50 chars max.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Rules
 2. Do not end the _Subject_ line with a period.
 3. Message _Subject_ **SHOULD** Begin with _at-least_ One Emoji(see below for [list of Suggested Emojis](#suggested-emojis)).
 4. Message Body **SHOULD** End with _at-least_ One [GitHub Issue](https://github.com/features#issues)/[Phabricator Task](http://phacility.com/phabricator/maniphest/) ID Reference, Ex. `Issue #27`, `Ref T27` or `Ref T27, T56` or `Fixes T8`.
-5. Total Characters of the _Subject Line_ **MUST** be _Less_ than or _Equal_ to **72** Chars Long.
+5. Total Characters of the _Subject Line_ **MUST** be _Less_ than or _Equal_ to **50** Chars Long.
 6. Wrap the _Message body_ at **72** characters.
 7. Use Valid [MarkDown](https://daringfireball.net/projects/markdown/basics) format in _Message Body_.
 8. Use the **Present Tense** ("Add feature" not "Added feature").


### PR DESCRIPTION
Most Git messages conventions uses 50 characters on subject line,
as it has been proved to be more readable.