### PR TITLE
:art: Added Jemoji gem for Github Pages build.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,3 @@
 theme: jekyll-theme-tactile
+gems:
+  - jemoji


### PR DESCRIPTION
Emoji doesn't show on repo's Github Pages site. 
(Hopefully) Adding Jemoji gem will fix it.