### PR TITLE
:books::sparkles: Add code coverage icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Suggested Emojis
 | :fire: | `:fire:` | when **removing code** or files, _maybe_ with `@CHANGED` Comment Tag |
 | :tractor: | `:tractor:` | when **change file structure**. Usually together with :art: |
 | :umbrella: | `:umbrella:` | when adding **tests** |
+| :microscope: | `:microscope:` | when adding **code coverage** |
 | :green_heart: | `:green_heart:` | when fixing the **CI** build |
 | :lock: | `:lock:` | when dealing with **security** |
 | :arrow_up: | `:arrow_up:` | when upgrading **dependencies** |

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Suggested Emojis
 | Emoji | Raw Emoji Code | Description |
 |:---:|:---:|---|
 | :art: | `:art:` | when improving the **format**/structure of the code |
+| :newspaper: | `:newspaper:` | when creating a **new file** |
 | :pencil: | `:pencil:` | when **performing minor changes/fixing** the code or language |
 | :racehorse: | `:racehorse:` | when improving **performance** |
 | :books: | `:books:` | when writing **docs** |


### PR DESCRIPTION
Code coverage is comming along addition of tests on the project,
it would be nice to have a icon to point it